### PR TITLE
Ensure all initial_ properties are initialized, even if undefined

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,10 @@ function processEvent(event) {
         $set_once: {
           initial_source: "direct",
           initial_referrer_parser: "direct_and_own_domains",
+          initial_medium: "undefined",
+          initial_campaign: "undefined",
+          initial_content: "undefined",
+          initial_term: "undefined",
         },
       },
     }
@@ -109,6 +113,8 @@ function processEvent(event) {
         initial_source: referrerData.source.toLowerCase(),
         initial_term: searchQuery,
         initial_referrer_parser: "snowplow",
+        initial_campaign: "undefined",
+        initial_content: "undefined",
       },
     },
   }


### PR DESCRIPTION
This sync merges an important bugfix causing problems with certain `utm` properties not being set in some rare use cases.