### PR TITLE
Added checks in case certain properties are missing from the event which caused the plugin to crash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,16 +6,16 @@ export function processEvent(event: PluginEvent) {
   if (typeof props === "undefined") {
     return event
   }
-
-  if (!props.$current_url) {
-    return event
-  }
   
   console.debug(
     `(Event: ${event.event}) URL: ${props.$current_url}, Referrer: ${props.$referrer}, Referring domain: ${props.$referring_domain}`,
   )
 
   // UTM tags
+
+  if (!props.$current_url) {
+    return event
+  }
 
   if (props.$current_url.indexOf("utm_") > -1) {
     const medium = getParameterByName("utm_medium", props.$current_url)

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,10 @@ export function processEvent(event: PluginEvent) {
     return event
   }
 
+  if (!props.$current_url) {
+    return event
+  }
+  
   console.debug(
     `(Event: ${event.event}) URL: ${props.$current_url}, Referrer: ${props.$referrer}, Referring domain: ${props.$referring_domain}`,
   )
@@ -54,6 +58,10 @@ export function processEvent(event: PluginEvent) {
 
   // Direct
 
+  if (!props.$referrer) {
+    return event
+  }
+
   if (
     props.$referrer === "$direct" ||
     isReferrerFromDirectDomain(props.$referrer)
@@ -83,6 +91,10 @@ export function processEvent(event: PluginEvent) {
   }
 
   // Snowplow parser
+
+  if (!props.$referring_domain) {
+    return event
+  }
 
   const referrerData = getMediumAndSourceFromReferrer(props.$referring_domain)
   const searchQuery = getSearchQueryFromUrl(


### PR DESCRIPTION
Our plugin seems to have been disabled due to an excessive amount of reported crashes. We pinpointed the problems down to missing event properties since some events don't originate from the web. These changes should fix the following issues.